### PR TITLE
fix(operator): stop manager office reconcile from conflict-looping

### DIFF
--- a/komputer-operator/internal/controller/komputeragent_controller.go
+++ b/komputer-operator/internal/controller/komputeragent_controller.go
@@ -329,6 +329,7 @@ func (r *KomputerAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		office := &komputerv1alpha1.KomputerOffice{}
 		if err := r.Get(ctx, types.NamespacedName{Name: officeName, Namespace: agent.Namespace}, office); err == nil {
 			needsUpdate := false
+			original := agent.DeepCopy()
 			// Ensure the manager also has the office label (issue: manager was missing it)
 			if agent.Labels == nil {
 				agent.Labels = map[string]string{}
@@ -343,7 +344,7 @@ func (r *KomputerAgentReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 				needsUpdate = true
 			}
 			if needsUpdate {
-				if err := r.Update(ctx, agent); err != nil {
+				if err := r.Patch(ctx, agent, client.MergeFrom(original)); err != nil {
 					log.Error(err, "Failed to update manager with office label/finalizer")
 					return ctrl.Result{}, err
 				}


### PR DESCRIPTION
## Summary
- The manager office label/finalizer block in `KomputerAgentReconciler.Reconcile` used `r.Update(ctx, agent)` (a full-object replace requiring an exact `resourceVersion` match), while every other mutation site in the same reconciler uses `r.Patch(ctx, agent, client.MergeFrom(original))`.
- Any concurrent write to the same `KomputerAgent` (e.g. the label patch earlier in the same reconcile, or a status write from elsewhere) bumped the server's `resourceVersion` out from under this `Update`, causing a `Conflict` error. controller-runtime requeued the reconcile against the same stale copy, which conflicted again — an unbounded retry loop that pegged the operator at its CPU limit (and drove up apiserver CPU as a side effect).
- Fix: switch this block to `Patch(MergeFrom(...))`, consistent with the rest of the file, so the write only applies the specific label/finalizer diff instead of requiring the whole object to be unchanged.

## Test plan
- [ ] Deploy to a cluster with a manager agent that has an office (e.g. one that previously showed repeated `"the object has been modified; please apply your changes to the latest version and try again"` errors in operator logs)
- [ ] Confirm operator logs no longer show `Failed to update manager with office label/finalizer` conflict errors for that agent
- [ ] Confirm `kubectl top pod -n komputer-system` for the operator drops back to idle CPU
- [ ] Confirm the manager agent still ends up with the `komputer.ai/office` label and `komputer.ai/office-cleanup` finalizer set correctly